### PR TITLE
💄 Different style logo for light / dark modes

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,9 @@
-
-<img src="https://user-images.githubusercontent.com/4883288/236483948-d97fcd5a-c68d-4d46-b8b6-e55e40f2c8e8.png" data-canonical-src="https://childmind.org" width="200" />
+<picture data-canonical-src="https://childmind.org" width="200px">
+  <source media="(prefers-color-scheme: dark)" srcset="https://childmind.widen.net/content/pi5q69g43j/png/ChildMindInstitute_Logo_Horizontal_OneColor_KO.png?w=200&keep=c&crop=yes&quality=80">
+  <source media="(prefers-color-scheme: light)" srcset="https://childmind.widen.net/content/9t01siy7f8/png/ChildMindInstitute_Logo_Horizontal_RGB.png?w=200&keep=c&crop=yes&quality=80">
+  <img alt="Child Mind Institute" src="https://childmind.widen.net/content/9t01siy7f8/png/ChildMindInstitute_Logo_Horizontal_RGB.png?w=200&keep=c&crop=yes&quality=80" width="200px">
+</picture>
 
 # Research @ the Child Mind Institute
 
 This is the GitHub organization for research, software products, tools, and services developed at the Child Mind Institute.
-


### PR DESCRIPTION
## Description

The [brand guidelines](https://childmind.widen.net/s/vtfshwjhf2#page=21) say

> !["Do not place the primary logo on a dark background" ](https://github.com/childmindresearch/.github/assets/5974438/f6fa9a16-bca2-43c8-a6c2-185d9a14dddb)

and

> !["Knockout logo can be used in instances where the logo will be placed on a dark or image background"](https://github.com/childmindresearch/.github/assets/5974438/eac96357-75c7-4366-b77f-19bed9741c25)

so this PR sets the knockout logo for dark mode and keeps the primary logo for light mode

## Screenshots

### Dark mode

![dark mode](https://github.com/childmindresearch/.github/assets/5974438/ce551ba9-1d8a-4328-bb83-b03587ce5441)

### Light mode

![light mode](https://github.com/childmindresearch/.github/assets/5974438/43a265cc-485c-4a6e-a7dc-efce7dbe4243)
